### PR TITLE
Logic Update for Buttons

### DIFF
--- a/src/components/QuestionCard.js
+++ b/src/components/QuestionCard.js
@@ -56,6 +56,7 @@ const QuestionCard = ({
                             onClick={handleNextQuestion}
                             type='button'
                             className='text-white bg-sky-700 hover:bg-sky-800 font-medium rounded-md text-sm px-5 py-2.5 mb-2 dark:bg-sky-600 dark:hover:bg-sky-700 focus:outline-none'
+                            disabled={question.id===quizLength?true:false} //When the user is at the last question , Next button should be disabled :)
                             >
                             Next
                             </button>
@@ -68,7 +69,8 @@ const QuestionCard = ({
                     <button onClick={handleScoreQuiz} type='button' className='text-white bg-gradient-to-r from-teal-400 via-teal-500 to-teal-600 hover:bg-gradient-to-br focus:ring-4 focus:ring-teal-300 font-medium rounded-md text-sm px-7 py-2.5 mr-6 mb-2 dark:bg-teal-600 dark:hover:bg-teal-700 dark:focus:ring-teal-800'>
                     Score My Quiz
                     </button>
-                    <button onClick={handleClearAnswers} type='button' className='text-white bg-gradient-to-r from-red-600 via-red-700 to-red-800 hover:bg-gradient-to-br focus:ring-4 focus:ring-red-300 font-medium rounded-md text-sm px-5 py-2.5 mb-2 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900'>
+                    <button onClick={handleClearAnswers} type='button' className='text-white bg-gradient-to-r from-red-600 via-red-700 to-red-800 hover:bg-gradient-to-br focus:ring-4 focus:ring-red-300 font-medium rounded-md text-sm px-5 py-2.5 mb-2 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900'
+                    disabled={localStorage.length === 0}>
                     Clear My Answers
                     </button>
                 </div>

--- a/src/components/ScoreReportCard_V1.js
+++ b/src/components/ScoreReportCard_V1.js
@@ -105,6 +105,7 @@ export default function ScoreReportCard (props){
                         onClick={props.handleNextQuestion}
                         type='button'
                         className='mr-4 text-white bg-sky-700 hover:bg-sky-800 rounded-md px-3 py-2 text-sm font-medium dark:bg-sky-600 dark:hover:bg-sky-700 focus:outline-none'
+                        disabled={localStorage.length === 0}
                         >
                         Next
                         </button>


### PR DESCRIPTION
When User Reaches last question , Next button should be disabled . This holds true for both quiz and quiz_report section.
Also , Clear my answers button should remain disabled as long as User doesn't select any answer

![Screenshot (11)](https://github.com/BrianAndrewOneil/quiz-app-tailwind/assets/94280987/17ce2374-998f-4fdb-b4a7-71cfa202334b)
![Screenshot (12)](https://github.com/BrianAndrewOneil/quiz-app-tailwind/assets/94280987/8ac2dd5e-7e93-4e1e-9398-d6b4eb53ff5a)
![Screenshot (14)](https://github.com/BrianAndrewOneil/quiz-app-tailwind/assets/94280987/5d410a35-04b0-4f95-8278-92ada99e3fac)
